### PR TITLE
Switch to using aws-sdk-java-models module

### DIFF
--- a/aws-java-sdk-generated-samples/pom.xml
+++ b/aws-java-sdk-generated-samples/pom.xml
@@ -76,11 +76,6 @@
 	    <version>3.10.0</version>
     </dependency>
     <dependency>
-	    <groupId>com.amazonaws</groupId>
-	    <artifactId>aws-java-sdk</artifactId>
-	    <version>[1.11,)</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.0</version>
@@ -99,7 +94,12 @@
     <dependency>
     	<groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-code-generator</artifactId>
-        <version>[1.11,)</version>
+        <version>1.11.49</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-models</artifactId>
+      <version>[1.11,)</version>
     </dependency>
   </dependencies>
 </project>

--- a/aws-java-sdk-handwritten-samples/pom.xml
+++ b/aws-java-sdk-handwritten-samples/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>[1.11,)</version>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.11.49</version>
       <optional>false</optional>
     </dependency>
   </dependencies>

--- a/aws-java-sdk-samples/pom.xml
+++ b/aws-java-sdk-samples/pom.xml
@@ -83,6 +83,12 @@
       <optional>false</optional>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.11.49</version>
+      <optional>false</optional>
+    </dependency>
+    <dependency>
       <groupId>sun.jdk</groupId>
       <artifactId>tools</artifactId>
       <version>1.8</version>


### PR DESCRIPTION
This should reduce the download size significantly during builds with a
fresh/empty local repo.